### PR TITLE
LRDOCS-9427 Support for EAP-TLS

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/configuring-a-vpn-server.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/configuring-a-vpn-server.md
@@ -6,7 +6,7 @@ The following scenario walks through how to set up an IPsec or OpenVPN VPN serve
    Configuration commands and values are subject to change and should be adapted for your specific environment.
 ```
 
-`EAP-TLS` and `EAP-MSCHAPV2` network protocols are both supported for VPN connections.
+`EAP-TLS` and `EAP-MSCHAPV2` authentication protocols are both supported for VPN connections.
 
 ## Basic Setup for an IPsec Server
 

--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
@@ -15,7 +15,13 @@ The client to site VPN feature supports the following protocols:
 * IPsec (IKEv2)
 * OpenVPN
 
-Subscribers can choose one of the protocols (IPSec or OpenVPN) to perform the connection from DXP Cloud console settings page for the desired environment. Any number of forwarding ports can be configured for the connection in the console UI. See [Connecting a VPN Server to DXP Cloud](./connecting-a-vpn-server-to-dxp-cloud.md) for more information.
+Subscribers can choose one of the protocols (IPSec or OpenVPN) to perform the connection from DXP Cloud console settings page for the desired environment. Any number of forwarding ports can be configured for the connection in the console UI.
+
+```note::
+   Using the ``IKEv2`` protocol with an IPsec server, you can either use ``MSCHAPv2`` or ``TLS``authentication protocols. See `Basic Setup for an IPsec Server <./configuring-a-vpn-server.md#basic-setup-for-an-ipsec-server>`__ for more information.
+```
+
+See [Connecting a VPN Server to DXP Cloud](./connecting-a-vpn-server-to-dxp-cloud.md) for more information.
 
 ## Connecting DXP Cloud to an IPSec VPN Server
 


### PR DESCRIPTION
`EAP-TLS` is now supported for Azure and IPsec servers. These changes intend to point out the steps of the process of configuring an IPsec server where changes must be made to use TLS instead of MSCHAPv2.